### PR TITLE
Npm search

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ winston.add(winston.transports.Console, {
 
 winston.info('NodeBB Package Manager - Initializing');
 
-new cronJob('*/15 * * * *', packages.registry.sync, null, true);
+new cronJob('*/30 * * * *', packages.registry.sync, null, true);
 new cronJob('0 0 * * *', packages.cleanUpUsage, null, true);
 
 

--- a/index.js
+++ b/index.js
@@ -48,7 +48,6 @@ winston.info('NodeBB Package Manager - Initializing');
 new cronJob('*/30 * * * *', packages.registry.sync, null, true);
 new cronJob('0 0 * * *', packages.cleanUpUsage, null, true);
 
-
 analytics.init();
 
 // Templates.js
@@ -62,20 +61,12 @@ app.listen(nconf.get('PORT') || 3000);
 winston.info('NodeBB Package Manager - Ready');
 
 // Check packaged sorted set. If missing, conduct initial sync
-packages.registry.init((err) => {
-	if (err) {
-		winston.error('[init] Could not initialise registry.');
-		winston.error(`[init] ${err.message}`);
-		return process.exit(1);
+// eslint-disable-next-line handle-callback-err
+rdb.zcard('packages', (err, numPackages) => {
+	if (numPackages === 0) {
+		winston.info('[init] No packages detected in database, running initial sync');
+		packages.registry.sync();
+	} else {
+		winston.info(`[init] Managing ${numPackages} packages`);
 	}
-
-	// eslint-disable-next-line handle-callback-err
-	rdb.zcard('packages', (err, numPackages) => {
-		if (numPackages === 0) {
-			winston.info('[init] No packages detected in database, running initial sync');
-			packages.registry.sync(true);
-		} else {
-			winston.info(`[init] Managing ${numPackages} packages`);
-		}
-	});
 });

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -359,6 +359,39 @@ Packages.registry.init = function (callback) {
 	});
 };
 
+function getNodeBBPackagesFromNpm(callback) {
+	let done = false;
+	let from = 0;
+	const nodebbPackage = /^(?:@[\w\-_]+\/)?nodebb-(plugin|theme|widget|rewards)-.*/;
+	let packages = [];
+	const pageSize = 250;
+	async.whilst(function (cb) {
+		cb(null, !done)
+	}, function (next) {
+		const url = `https://registry.npmjs.com/-/v1/search?text=nodebb-&size=${pageSize}&from=${from}`
+		request({
+			url: url,
+			json: true,
+		}, (err, res, body) => {
+			if (err || res.statusCode !== 200) {
+				return next(err || new Error(`Error loading packages from npm ${res.statusCode}`));
+			}
+			if (body.objects.length === 0) {
+				done = true;
+			} else {
+				packages = packages.concat(
+					body.objects.map(pkg => pkg.package.name)
+						.filter(pkgName => pkgName.match(nodebbPackage))
+				);
+				from += pageSize;
+			}
+			next();
+		});
+	}, function (err) {
+		callback(err, packages);
+	});
+}
+
 Packages.registry.sync = function (initial) {
 	const now = new Date();
 	const date = `${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
@@ -366,53 +399,13 @@ Packages.registry.sync = function (initial) {
 	winston.info(`[packages.registry.sync] Starting sync @ ${date}`);
 	winston.verbose(`[packages.registry.sync] last_seq: ${Packages.registry.last_seq}`);
 
-	const nodebbPackage = /^(?:@[\w\-_]+\/)?nodebb-(plugin|theme|widget|rewards)-.*/;
-	// the initial url no longer seems to work. Addl. research is required
-	const url = initial ? 'https://registry.npmjs.com/-/_view/byKeyword?startkey=[%22nodebb%22]&endkey=[%22nodebb%22,{}]&group_level=2' : `https://replicate.npmjs.com/registry/_changes?since=${Packages.registry.last_seq}`;
-	let packages;
-
-	request({
-		url: url,
-		json: true,
-	}, (err, res, body) => {
-		if (!err && res.statusCode === 200) {
-			if (typeof body === 'string') {
-				try {
-					body = JSON.parse(body);
-				} catch (err) {
-					if (err) { winston.error(err.stack); }
-					return;
-				}
-			}
-			if (!initial) {
-				// Track instances where no packages returned by npm (last_seq unchanged)
-				if (parseInt(Packages.registry.last_seq, 10) === parseInt(body.last_seq, 10)) {
-					Packages.registry.seq_stale += 1;
-				} else {
-					Packages.registry.seq_stale = 0;
-				}
-
-				Packages.registry.last_seq = body.last_seq;
-
-				body.results = body.results || [];
-
-				packages = body.results.map(changeset => changeset.id).filter(pkgName => pkgName.match(nodebbPackage));
-			} else {
-				body.rows = body.rows || [];
-
-				packages = body.rows.map(row => row.key[1]).filter(pkgName => nodebbPackage.test(pkgName));
-			}
-
-			if (!packages.length) {
-				winston.info('[packages.registry.sync] No packages in need of updating, updating last_seq');
-				return Packages.registry.syncComplete();
-			}
-
+	getNodeBBPackagesFromNpm(function (err, packages) {
+		if (!err && packages.length) {
 			winston.info(`[packages.registry.sync] Found ${packages.length} package(s) in need of updating!`);
 
 			async.eachLimit(
 				packages,
-				50,
+				100,
 				Packages.registry.update,
 				Packages.registry.syncComplete
 			);
@@ -427,28 +420,9 @@ Packages.registry.syncComplete = function (err) {
 	if (err) {
 		winston.error(`[packages.registry.sync] Sync encountered an error while updating registry: ${err.message}`);
 		winston.error(err.stack);
+		return;
 	}
-
-	if (Packages.registry.seq_stale < 4) {
-		Packages.clearCaches();
-		rdb.set('npm:last_seq', Packages.registry.last_seq, (err) => {
-			if (err) {
-				winston.error('[packages.registry.sync] Sync encountered an error while updating last_seq');
-				winston.error(err.stack);
-			}
-		});
-
-		winston.info(`[packages.registry.sync] Sync complete, new last_seq: ${Packages.registry.last_seq}`);
-	} else {
-		winston.warn('[packages.registry.sync] Stale return from npm detected! Resetting last_seq...');
-		Packages.registry.last_seq = 0;
-		rdb.set('npm:last_seq', 0, (err) => {
-			if (err) {
-				winston.error('[packages.registry.sync] Sync encountered an error while updating last_seq');
-				winston.error(err.stack);
-			}
-		});
-	}
+	Packages.clearCaches();
 };
 
 Packages.registry.get = function (name, callback) {
@@ -515,9 +489,6 @@ Packages.registry.save = function (pkgData, callback) {
 	}
 
 	winston.info(`[packages.registry.save] Updating ${pkgData.name}`);
-
-	// If latest dist data says this package isn't to be indexed, skip (or remove from index)
-	if (dist.hasOwnProperty('nbbpm') && dist.nbbpm.index === false) { return Packages.registry.delete(dist.name, callback); }
 
 	const metaData = {
 		name: dist.name,

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -392,12 +392,11 @@ function getNodeBBPackagesFromNpm(callback) {
 	});
 }
 
-Packages.registry.sync = function (initial) {
+Packages.registry.sync = function () {
 	const now = new Date();
 	const date = `${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
 
 	winston.info(`[packages.registry.sync] Starting sync @ ${date}`);
-	winston.verbose(`[packages.registry.sync] last_seq: ${Packages.registry.last_seq}`);
 
 	getNodeBBPackagesFromNpm(function (err, packages) {
 		if (!err && packages.length) {
@@ -465,7 +464,6 @@ Packages.registry.get = function (name, callback) {
 };
 
 Packages.registry.update = function (pkgName, next) {
-	// winston.info(`[packages.registry.update] Starting update for ${pkgName}`);
 	async.waterfall([
 		async.apply(Packages.registry.get, pkgName),
 		Packages.registry.save,
@@ -490,8 +488,6 @@ Packages.registry.save = function (pkgData, callback) {
 		winston.verbose(`[packages.registry.save] SKIP ${pkgData.name}`);
 		return Packages.registry.remove(pkgData.name, callback);
 	}
-
-	// winston.info(`[packages.registry.save] Updating ${pkgData.name}`);
 
 	const metaData = {
 		name: dist.name,
@@ -524,7 +520,6 @@ Packages.registry.save = function (pkgData, callback) {
 };
 
 Packages.registry.remove = function (pkgName, callback) {
-	winston.verbose(`[packages.registry.remove] Removing ${pkgName} from registry`);
 	rdb.multi()
 		.del(`package:${pkgName}`)
 		.zrem('packages', pkgName)
@@ -532,8 +527,6 @@ Packages.registry.remove = function (pkgName, callback) {
 };
 
 Packages.registry.buildCompatibilityTable = function (pkgData, callback) {
-	winston.verbose(`[packages.registry.buildCompatibilityTable] Start "${pkgData.name}"`);
-
 	let version;
 	const compatibility = {};
 	const pkgVersions = Object.keys(pkgData.versions).sort(semver.compare);
@@ -559,7 +552,6 @@ Packages.registry.buildCompatibilityTable = function (pkgData, callback) {
 			}
 		}
 
-		winston.verbose(`[packages.registry.buildCompatibilityTable] Finish "${pkgData.name}"`);
 		callback(null, compatibility);
 	});
 };

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -487,7 +487,7 @@ Packages.registry.save = function (pkgData, callback) {
 	const syncDate = Date.now();
 
 	if (dist.hasOwnProperty('nbbpm') && dist.nbbpm.index === false) {
-		winston.info(`[packages.registry.save] SKIP ${pkgData.name}`);
+		winston.verbose(`[packages.registry.save] SKIP ${pkgData.name}`);
 		return Packages.registry.remove(pkgData.name, callback);
 	}
 
@@ -524,7 +524,7 @@ Packages.registry.save = function (pkgData, callback) {
 };
 
 Packages.registry.remove = function (pkgName, callback) {
-	winston.info(`[packages.registry.remove] Removing ${pkgName} from registry`);
+	winston.verbose(`[packages.registry.remove] Removing ${pkgName} from registry`);
 	rdb.multi()
 		.del(`package:${pkgName}`)
 		.zrem('packages', pkgName)

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -20,10 +20,7 @@ const rdb = require('./redis');
 const Packages = {};
 
 // Namespaces
-Packages.registry = {
-	last_seq: undefined,
-	seq_stale: 0,
-};
+Packages.registry = {};
 
 Packages.clearCaches = function (pkgName) {
 	if (pkgName) {
@@ -341,24 +338,6 @@ Packages.cleanUpUsage = function () {
 
 // Registry functions
 
-Packages.registry.init = function (callback) {
-	// Retrieve seq number from the local db, or if not, use provided number in environment variable
-	rdb.get('npm:last_seq', (err, seq) => {
-		if (err) {
-			return callback(err);
-		}
-
-		Packages.registry.last_seq = seq || nconf.get('NPM_LAST_SEQ');
-
-		if (!Packages.registry.last_seq) {
-			Packages.registry.last_seq = 0;
-		}
-
-		winston.info(`[packages.registry.init] Using last_seq: ${Packages.registry.last_seq}`);
-		callback();
-	});
-};
-
 function getNodeBBPackagesFromNpm(callback) {
 	let done = false;
 	let from = 0;
@@ -404,7 +383,7 @@ Packages.registry.sync = function () {
 
 			async.eachLimit(
 				packages,
-				100,
+				50,
 				Packages.registry.update,
 				Packages.registry.syncComplete
 			);

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -136,6 +136,9 @@ Packages.getPlugin = function (pkgName, callback) {
 		pkgData: async.apply(Packages.registry.get, pkgName),
 		payload: async.apply(rdb.hgetall.bind(rdb), `package:${pkgName}`),
 	}, (err, results) => {
+		if (err) {
+			return callback(err);
+		}
 		const versions = [];
 		// eslint-disable-next-line no-restricted-syntax
 		for (const key in results.pkgData.versions) {
@@ -145,7 +148,7 @@ Packages.getPlugin = function (pkgName, callback) {
 		}
 		results.payload.valid = versions;
 
-		callback(err, !err ? results.payload : undefined);
+		callback(null, results.payload);
 	});
 };
 
@@ -424,17 +427,22 @@ Packages.registry.get = function (name, callback) {
 					url: `https://replicate.npmjs.com/registry/${encodeURIComponent(name)}`,
 					json: true,
 				}, (err, res, body) => {
-					if (!err && res.statusCode === 200) {
+					if (err) {
+						winston.error(err.stack);
+						next(err);
+						return;
+					}
+					if (res.statusCode === 200) {
 						// Save to cache and return
 						skimdbCache.set(name, body);
 						next(undefined, body);
 					} else if (res.statusCode === 404) {
 						body.name = name;
 						next(undefined, body);
-					} else {
-						err = err || new Error('registry-error');
-						winston.error(err.stack);
-						next(err);
+					} else if (res.statusCode !== 200) {
+						winston.error('non 200 code ' + res.statusCode);
+						winston.error(body || 'no-body');
+						next(new Error('non 200 code ' + res.statusCode));
 					}
 				});
 			}

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -422,6 +422,9 @@ Packages.registry.syncComplete = function (err) {
 		winston.error(err.stack);
 		return;
 	}
+	const now = new Date();
+	const date = `${now.toLocaleDateString()} ${now.toLocaleTimeString()}`;
+	winston.info(`[packages.registry.sync] Sync complete @ ${date}`);
 	Packages.clearCaches();
 };
 

--- a/lib/packages.js
+++ b/lib/packages.js
@@ -462,7 +462,7 @@ Packages.registry.get = function (name, callback) {
 };
 
 Packages.registry.update = function (pkgName, next) {
-	winston.info(`[packages.registry.update] Starting update for ${pkgName}`);
+	// winston.info(`[packages.registry.update] Starting update for ${pkgName}`);
 	async.waterfall([
 		async.apply(Packages.registry.get, pkgName),
 		Packages.registry.save,
@@ -488,7 +488,7 @@ Packages.registry.save = function (pkgData, callback) {
 		return Packages.registry.remove(pkgData.name, callback);
 	}
 
-	winston.info(`[packages.registry.save] Updating ${pkgData.name}`);
+	// winston.info(`[packages.registry.save] Updating ${pkgData.name}`);
 
 	const metaData = {
 		name: dist.name,


### PR DESCRIPTION
switch to loading packages from npm search https://github.com/npm/registry/blob/master/docs/REGISTRY-API.md#get-v1search

increased build time to 30mins

the old call to 
https://replicate.npmjs.com/registry/_changes?since=0 takes forever so new packages werent getting updated

this branch is on live now